### PR TITLE
feat: add Termux installation scripts and configuration for SSHD and …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__
 .env
 secret
 logs
+config/config.yaml

--- a/README.md
+++ b/README.md
@@ -48,7 +48,28 @@ python3 -m venv .venv && source .venv/bin/activate
 pip install -r requirements.txt
 ```
 
+### Termux-first setup (recommended)
+If you are installing this on a real Android/Termux device, run the installer from the cloned repo:
+
+``` bash
+bash scripts/install_termux.sh
+```
+
+This script:
+- detects Termux and asks before installing missing packages
+- creates `config/config.yaml` from the example template if it does not exist yet
+- installs the Termux boot + notification helpers
+- copies the Termux boot files and notification bridge into the correct Termux locations
+- creates/updates the project venv and `.env` template
+- prepares the proot/Ubuntu bootstrap files for the first boot
+
 ### 2. Configure your environment
+
+Copy and edit your local config file (this file is gitignored and should hold your real provider keywords):
+
+``` bash
+cp config/config.example.yaml config/config.yaml
+```
 
 Copy and edit your `.env` file:
 
@@ -111,6 +132,14 @@ websites:
 ------------------------------------------------------------------------
 
 ## 🚀 Running the App
+
+### Termux boot workflow
+1. Run `bash scripts/install_termux.sh` from the repo.
+2. Confirm the package and boot helper prompts when asked.
+3. Open Termux once and allow the requested permissions so `termux-boot` and `termux-notification` can start.
+4. Reboot the phone or launch `termux-boot` manually to start the Ubuntu/proot runtime.
+5. The installer will print the SSH/proot startup guidance and the IP-check commands to use after the first boot.
+
 
 ### ▶ Manual one-time run
 

--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -1,4 +1,5 @@
-# config.yaml
+# Example provider config. Copy this to config/config.yaml on your phone.
+# config/config.yaml is gitignored and should hold your real keywords/recipients.
 websites:
   - id: "ttec_north_east"
     title: "TTEC"
@@ -7,20 +8,19 @@ websites:
       - "north"
       - "east"
     location_keywords:
-      - "Perseverance"
-      - "Moka"
-      - "Fernandez"
-      - "Saddle"
+      - "Example Area"
+      - "Example Town"
+      - "Example Road"
     status_inactive_keyword: "CANCELLED"
-    schedule: "0 6 * * mon,wed"
+    schedule: "20 22 * * *"
+
   - id: "ttec_east_only"
     title: "TTEC"
     url: "https://ttec.co.tt/cis/outages_public.html"
     area_keywords:
       - "east"
     location_keywords:
-      - "Hummingbird"
-      - "Ojoe"
-      - "Foster"
+      - "Example District"
+      - "Example Village"
     status_inactive_keyword: "CANCELLED"
-    schedule: "0 6 * * mon,wed"
+    schedule: "20 22 * * *"

--- a/runner.py
+++ b/runner.py
@@ -105,32 +105,43 @@ def _run_provider_impl(provider: dict):
     status_inactive_keyword = provider.get("status_inactive_keyword", "CANCELLED")
 
     recipients = recipients_for_provider(provider_id) if provider_id else []
+    logger.info(f"[{title}] provider_id={provider_id}, recipients_count={len(recipients)}")
     if not recipients:
         logger.error(f"[{title}] No recipients for provider_id={provider_id}. Skipping email.")
         notify(f"{title}", f"⚠️ No recipients • start {fmt_ts(t_start)}", "default")
-    else:
-        logger.info(f"[{title}] recipients={len(recipients)}")
+        return
 
     logger.info(f"[{title}] Starting scrape {url}")
     toast(f"[{title}] started @ {t_start.strftime('%H:%M:%S')}")
 
-    outages = scrape_outages(url, area_keywords, location_keywords, status_inactive_keyword)
+    try:
+        outages = scrape_outages(url, area_keywords, location_keywords, status_inactive_keyword)
+        logger.info(f"[{title}] Scraped {len(outages)} raw outage(s)")
+    except Exception as e:
+        logger.exception(f"[{title}] Scraping failed: {e}")
+        raise
 
     events = []
     for o in outages:
-        ev = create_event(
-            date=o["date"],
-            time=o["time"],
-            title=title,
-            status=o["status"],
-            location=o["location"],
-            description=o["description"],
-            logger=logger
-        )
-        if ev:
-            ev["date_str"] = o["date"]
-            ev["status"] = o["status"]
-            events.append(ev)
+        try:
+            ev = create_event(
+                date=o["date"],
+                time=o["time"],
+                title=title,
+                status=o["status"],
+                location=o["location"],
+                description=o["description"],
+                logger=logger
+            )
+            if ev:
+                ev["date_str"] = o["date"]
+                ev["status"] = o["status"]
+                events.append(ev)
+                logger.debug(f"[{title}] Event created: {o['location']} on {o['date']}")
+            else:
+                logger.debug(f"[{title}] Event creation returned None for {o['location']}")
+        except Exception as e:
+            logger.warning(f"[{title}] Failed to create event for {o.get('location', 'unknown')}: {e}")
 
     if not events:
         t_end = now_tt()
@@ -139,9 +150,16 @@ def _run_provider_impl(provider: dict):
         notify(f"{title}", f"ℹ️ No events • {fmt_ts(t_start)} → {fmt_ts(t_end)} • {dur}", "low")
         return
 
+    logger.info(f"[{title}] Processing {len(events)} event(s) for email")
     ics_name = f"service_outage_{title.lower().replace(' ','_')}_{now_tt().strftime('%Y%m%d')}.ics"
     ics_path = os.path.expanduser(f"./logs/{ics_name}")
-    save_ics_file(events, ics_path, logger=logger)
+    
+    try:
+        save_ics_file(events, ics_path, logger=logger)
+        logger.info(f"[{title}] ICS file saved to {ics_path}")
+    except Exception as e:
+        logger.exception(f"[{title}] Failed to save ICS file: {e}")
+        raise
 
     table_html = format_events_as_html(events)
     crit_html = format_criteria_table([(title, url, area_keywords, location_keywords)])
@@ -153,13 +171,19 @@ def _run_provider_impl(provider: dict):
         "<p>Best regards,<br/>Service Outage Monitor</p>"
     )
 
-    send_email_with_attachment(
-        subject=subject,
-        body_html=body_html,
-        attachment_path=ics_path,
-        recipients=recipients,
-        logger=logger
-    )
+    logger.info(f"[{title}] Sending email to {len(recipients)} recipient(s): {recipients}")
+    try:
+        send_email_with_attachment(
+            subject=subject,
+            body_html=body_html,
+            attachment_path=ics_path,
+            recipients=recipients,
+            logger=logger
+        )
+        logger.info(f"[{title}] Email sent successfully")
+    except Exception as e:
+        logger.exception(f"[{title}] Email sending failed: {e}")
+        raise
 
     t_end = now_tt()
     dur = human_dur((t_end - t_start).total_seconds())
@@ -172,10 +196,12 @@ def _run_provider_impl(provider: dict):
 def run_provider(provider: dict):
     t0 = time.time()
     try:
+        logger.info(f"[{provider.get('title', 'Provider')}] JOB TRIGGERED")
         return _run_provider_impl(provider)
     except Exception as e:
         dt = time.time() - t0
         title = provider.get("title", "Provider")
+        logger.exception(f"[{title}] Job execution failed after {human_dur(dt)}")
         notify(title, f"❌ {type(e).__name__} • {human_dur(dt)}", "max", sticky=True)
         raise
 
@@ -225,6 +251,8 @@ def main():
     print("[runner] APScheduler started", flush=True)
     jobs = scheduler.get_jobs()
     logger.info("APScheduler started. Press Ctrl+C to exit. jobs=%d", len(jobs))
+    for job in jobs:
+        logger.info(f"  Job: {job.id} | Next run: {job.next_run_time}")
     notify("Outage Monitor", f"Scheduler started • {len(jobs)} job(s) • {fmt_ts(now_tt())}", "low")
 
     def _shutdown(signum, frame):

--- a/scripts/install_termux.sh
+++ b/scripts/install_termux.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# Install and wire the Termux/proot runtime for this repo.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "$SCRIPT_DIR/.." && pwd)"
+TERMUX_HOME="${HOME:-/data/data/com.termux/files/home}"
+BOOT_DIR="$TERMUX_HOME/.termux/boot"
+LOCAL_BIN="$TERMUX_HOME/.local/bin"
+LOG_DIR="$TERMUX_HOME/logs"
+PROJECT_DIR="$TERMUX_HOME/projects/apps/service-outage-monitor"
+
+if ! command -v pkg >/dev/null 2>&1; then
+  echo "[install] This installer must run inside Termux." >&2
+  exit 1
+fi
+
+prompt_yes_no() {
+  local prompt="$1"
+  local default="${2:-n}"
+  local answer=""
+  while true; do
+    if [[ "$default" == "y" ]]; then
+      read -r -p "$prompt [Y/n]: " answer
+      answer="${answer:-y}"
+    else
+      read -r -p "$prompt [y/N]: " answer
+      answer="${answer:-n}"
+    fi
+    case "${answer,,}" in
+      y|yes) return 0 ;;
+      n|no) return 1 ;;
+      *) echo "Please answer yes or no." ;;
+    esac
+  done
+}
+
+say() { printf '\n[install] %s\n' "$1"; }
+
+say "Detected Termux user: $(whoami)"
+say "Repo root: $REPO_ROOT"
+
+if [[ ! -f "$REPO_ROOT/requirements.txt" ]]; then
+  echo "[install] requirements.txt not found in $REPO_ROOT" >&2
+  exit 1
+fi
+
+if prompt_yes_no "Install/update required Termux packages (pkg update + git/python/proot-distro/termux-api/termux-tools/tmux/openssh/curl)?"; then
+  say "Running pkg update..."
+  pkg update -y
+  pkg install -y git python proot-distro termux-api termux-tools tmux openssh curl
+fi
+
+if prompt_yes_no "Install Termux boot support package too?"; then
+  pkg install -y termux-boot || true
+fi
+
+mkdir -p "$BOOT_DIR" "$LOCAL_BIN" "$LOG_DIR"
+
+say "Installing bridge helper to $LOCAL_BIN/tt_notify_bridge.py"
+cp "$REPO_ROOT/scripts/tt_notify_bridge.py" "$LOCAL_BIN/tt_notify_bridge.py"
+chmod +x "$LOCAL_BIN/tt_notify_bridge.py"
+
+say "Installing Termux boot files to $BOOT_DIR"
+cp "$REPO_ROOT/scripts/termux_boot_start.sh" "$BOOT_DIR/start.sh"
+cp "$REPO_ROOT/scripts/termux_boot_00_start_ubuntu_sshd.sh" "$BOOT_DIR/00_start_ubuntu_sshd.sh"
+cp "$REPO_ROOT/scripts/termux_boot_01_notify_bridge.sh" "$BOOT_DIR/01_notify_bridge.sh"
+chmod +x "$BOOT_DIR"/*.sh
+
+say "Installing proot helper shells into $TERMUX_HOME"
+cp "$REPO_ROOT/scripts/proot_startup.sh" "$TERMUX_HOME/startup.sh"
+cp "$REPO_ROOT/scripts/proot_sshd_commands.sh" "$TERMUX_HOME/sshd_commands.sh"
+cp "$REPO_ROOT/scripts/proot_start-sshd-once.sh" "$TERMUX_HOME/start-sshd-once.sh"
+chmod +x "$TERMUX_HOME/startup.sh" "$TERMUX_HOME/sshd_commands.sh" "$TERMUX_HOME/start-sshd-once.sh"
+
+say "Checking proot distro availability"
+if command -v proot-distro >/dev/null 2>&1; then
+  if ! proot-distro list 2>/dev/null | grep -q 'ubuntu-jammy'; then
+    say "Installing proot distro 'ubuntu-jammy'..."
+    proot-distro install ubuntu-jammy
+  else
+    say "proot distro 'ubuntu-jammy' is already installed."
+  fi
+else
+  echo "[install] proot-distro not found after package install; please reopen Termux and rerun." >&2
+  exit 1
+fi
+
+say "Creating project directory if needed: $PROJECT_DIR"
+mkdir -p "$PROJECT_DIR"
+
+if [[ -d "$REPO_ROOT/.git" ]]; then
+  say "Repo already present at $REPO_ROOT"
+else
+  say "This installer expects the repo to already be cloned into $REPO_ROOT"
+fi
+
+if [[ ! -f "$REPO_ROOT/requirements.txt" ]]; then
+  echo "[install] Missing requirements.txt in repo. Clone the project first." >&2
+  exit 1
+fi
+
+say "Creating a local virtualenv for the project"
+python -m venv "$REPO_ROOT/.venv" || python3 -m venv "$REPO_ROOT/.venv"
+"$REPO_ROOT/.venv/bin/python" -m pip install --upgrade pip
+"$REPO_ROOT/.venv/bin/pip" install -r "$REPO_ROOT/requirements.txt"
+
+say "Preparing local config from the example template if needed"
+if [[ ! -f "$REPO_ROOT/config/config.yaml" ]]; then
+  cp "$REPO_ROOT/config/config.example.yaml" "$REPO_ROOT/config/config.yaml"
+  echo "[install] Created $REPO_ROOT/config/config.yaml from the example template. Edit your real keywords here."
+fi
+
+say "Preparing .env from .env.example if it does not exist"
+if [[ ! -f "$REPO_ROOT/.env" ]]; then
+  cp "$REPO_ROOT/.env.example" "$REPO_ROOT/.env"
+  echo "[install] Created $REPO_ROOT/.env. Edit SMTP and recipient settings before first run."
+fi
+
+say "Boot helper installed. Next steps:"
+printf '  1. Open Termux once and allow the boot/notification permissions when prompted.\n'
+printf '  2. Reopen Termux and run: termux-boot  (or just reboot the phone).\n'
+printf '  3. Check the bridge with: python %s/tt_notify_bridge.py --token super-secret-change-me\n' "$LOCAL_BIN"
+printf '  4. To verify the proot SSH endpoint, run: proot-distro login ubuntu-jammy -- bash -lc "bash /root/start-sshd-once.sh"\n'
+printf '  5. Use this command to inspect the IP after the boot script runs: ifconfig 2>/dev/null | grep -Eo \"inet (addr:)?([0-9]{1,3}\.){3}[0-9]{1,3}\" | grep -v 127.0.0.1\n'
+
+say "Installer finished."

--- a/scripts/proot_sshd_commands.sh
+++ b/scripts/proot_sshd_commands.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+set -euo pipefail
+
+start_sshd_debug() {
+  echo "Starting SSHD in debug mode with config: /etc/ssh/sshd_config.min"
+  mkdir -p /var/log/proot
+  /usr/sbin/sshd -E /var/log/proot/sshd.log -D -e -f /etc/ssh/sshd_config.min
+}
+
+stop_sshd() {
+  echo "Stopping SSHD service"
+  pkill -x sshd || echo "SSHD is not running"
+}
+
+check_sshd_status() {
+  if pgrep -x sshd > /dev/null; then
+    echo "SSHD is running"
+    exit 0
+  else
+    echo "SSHD is not running"
+    exit 1
+  fi
+}
+
+restart_sshd() {
+  echo "Restarting SSHD service"
+  stop_sshd
+  start_sshd_debug
+}
+
+test_ssh_connection() {
+  echo "Testing SSH connection on 127.0.0.1:30022"
+  if command -v nc >/dev/null 2>&1; then
+    nc -vz 127.0.0.1 30022
+  else
+    echo "nc (netcat) not found. Install it first."
+    exit 2
+  fi
+}
+
+monitor_ssh_logs() {
+  mkdir -p /var/log/proot
+  : > /var/log/proot/sshd.log
+  echo "Monitoring SSH logs (/var/log/proot/sshd.log)"
+  tail -f /var/log/proot/sshd.log
+}
+
+clear_ssh_logs() {
+  mkdir -p /var/log/proot
+  echo "Clearing SSH logs"
+  > /var/log/proot/sshd.log
+}
+
+show_menu() {
+  cat <<'MENU'
+===== SSHD Command Menu =====
+1) Start SSHD in Debug Mode
+2) Stop SSHD
+3) Check SSHD Status
+4) Restart SSHD
+5) Test SSH Connection Locally
+6) Monitor SSH Logs
+7) Clear SSH Logs
+8) Exit
+MENU
+}
+
+usage() {
+  cat <<'HELP'
+Usage:
+  sshd_commands.sh                 # show menu
+  sshd_commands.sh <option>        # run by number (1-7)
+  sshd_commands.sh <name>          # run by name: start|stop|status|restart|test|monitor|clear|help
+HELP
+}
+
+execute_command() {
+  local sel="${1:-}"
+  case "$sel" in
+    1|start) start_sshd_debug ;;
+    2|stop) stop_sshd ;;
+    3|status) check_sshd_status ;;
+    4|restart) restart_sshd ;;
+    5|test) test_ssh_connection ;;
+    6|monitor) monitor_ssh_logs ;;
+    7|clear) clear_ssh_logs ;;
+    8|exit|quit) echo "Exiting..."; exit 0 ;;
+    h|-h|--help|help) usage; exit 0 ;;
+    *) echo "Invalid option: $sel"; usage; exit 64 ;;
+  esac
+}
+
+if [[ $# -gt 0 ]]; then
+  for arg in "$@"; do
+    execute_command "$arg"
+  done
+  exit 0
+fi
+
+while true; do
+  show_menu
+  read -rp "Please choose an option (1-8): " choice
+  execute_command "$choice"
+  echo
+ done

--- a/scripts/proot_start-sshd-once.sh
+++ b/scripts/proot_start-sshd-once.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+exec 9>/run/ubuntu-sshd.lock
+flock -n 9 || exit 0
+
+mkdir -p /run/sshd /var/log/proot
+rm -f /run/sshd.pid || true
+
+ssh-keygen -A >/dev/null 2>&1 || true
+/usr/sbin/sshd -t -f /etc/ssh/sshd_config.min
+/usr/sbin/sshd -f /etc/ssh/sshd_config.min -E /var/log/proot/sshd.log -o PidFile=/run/sshd.pid
+echo "[start-sshd-once] started on 0.0.0.0:30022" >> /var/log/proot/startup.log

--- a/scripts/proot_startup.sh
+++ b/scripts/proot_startup.sh
@@ -1,0 +1,200 @@
+#!/usr/bin/env bash
+# /root/startup.sh — proot bootstrap for outage-runner
+set -Eeuo pipefail
+export TZ=America/Port_of_Spain
+
+shopt -s expand_aliases
+[ -f /root/.bash_aliases ] && source /root/.bash_aliases
+
+APP_DIR="/root/projects/apps/service-outage-monitor"
+VENV_ACTIVATE="$APP_DIR/.venv/bin/activate"
+RUNNER="$APP_DIR/runner.py"
+LOG_DIR="$APP_DIR/logs/outage-runner"
+mkdir -p "$LOG_DIR"
+
+# ---- avoid double-runs on boot thrash
+LOCK="/var/run/outage-runner.lock"
+mkdir -p /var/run
+exec 9> "$LOCK" || { echo "[startup] cannot open lock"; exit 1; }
+flock -n 9 || { echo "[startup] another instance running, exiting"; exit 0; }
+
+# ---- central logs
+mkdir -p /var/log/proot
+exec >>/var/log/proot/startup.log 2>&1
+echo "[startup] $(date) begin"
+
+# ---- bridge URL/token (fallbacks)
+: "${TT_BRIDGE_URL:=${BRIDGE_URL:-http://127.0.0.1:8787}}"
+: "${TT_BRIDGE_TOKEN:=super-secret-change-me}"
+: "${TT_BRIDGE_ENABLED:=1}"
+
+wait_bridge() {
+  local url="${TT_BRIDGE_URL}"
+  for _ in $(seq 1 60); do
+    curl -m 1 -s "$url/health" >/dev/null 2>&1 && return 0
+    sleep 1
+  done
+  return 1
+}
+
+preflight() {
+  echo "[startup] preflight…"
+  sleep 35
+
+  if wait_bridge; then
+    curl -m 1 -sS -X POST "$TT_BRIDGE_URL/toast" \
+      -H "Content-Type: application/json" \
+      -d "{\"text\":\"🔌 proot startup begin @ $(date +%H:%M:%S)\"}" >/dev/null 2>&1 || true
+  else
+    echo "[startup] WARN: bridge not healthy after 60s; proceeding anyway"
+  fi
+
+  for _ in {1..60}; do
+    [ -d "$APP_DIR" ] && [ -f "$VENV_ACTIVATE" ] && [ -f "$RUNNER" ] && break
+    sleep 1
+  done
+  if [ ! -d "$APP_DIR" ] || [ ! -f "$VENV_ACTIVATE" ] || [ ! -f "$RUNNER" ]; then
+    echo "[startup] FATAL: APP_DIR/VENV/RUNNER missing"
+    exit 1
+  fi
+
+  : "${PYTHONPATH:=}"
+  export PYTHONPATH="$APP_DIR:$APP_DIR/src${PYTHONPATH:+:$PYTHONPATH}"
+
+  echo "[startup] preflight ok"
+}
+
+preflight
+
+bash /root/start-sshd-once.sh || echo "[startup] sshd start script reported an issue (continuing)"
+
+echo "[startup] launching runner in tmux…"
+curl -m 1 -sS -X POST "$TT_BRIDGE_URL/toast" -H "Content-Type: application/json" \
+  -d '{"text":"▶️ launching outage-runner (tmux)"}' >/dev/null 2>&1 || true
+
+CHILD_SCRIPT="/tmp/outage_runner_tmux.sh"
+cat > "$CHILD_SCRIPT" <<'SH'
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+BOOTLOG="/root/outage_runner.bootstrap.log"
+echo "[child] $(date) child starting; LOG_DIR='${LOG_DIR-}' APP_DIR='${APP_DIR-}'" >> "$BOOTLOG"
+
+[ -z "${LOG_DIR:-}" ] && LOG_DIR="/root"
+mkdir -p "$LOG_DIR"
+exec >> "$LOG_DIR/runner.out" 2>&1
+set -x
+
+echo "[tmux] $(date) begin"
+echo "[tmux] env check: LOG_DIR=$LOG_DIR APP_DIR=$APP_DIR VENV_ACTIVATE=$VENV_ACTIVATE RUNNER=$RUNNER"
+echo "[tmux] PWD before: $(pwd)"
+
+export TT_BRIDGE_URL TT_BRIDGE_TOKEN TT_BRIDGE_ENABLED
+: "${PYTHONPATH:=}"; export PYTHONPATH="$APP_DIR:$APP_DIR/src:$PYTHONPATH"
+
+if [ -n "${VENV_ACTIVATE:-}" ] && [ -f "$VENV_ACTIVATE" ]; then
+  source "$VENV_ACTIVATE"
+fi
+
+cd "$APP_DIR" || { echo "[tmux] ERROR: cd $APP_DIR"; exec bash; }
+
+echo "[tmux] exports/venv done"; python3 -V || true; which python3 || true
+
+if [ -n "${TT_BRIDGE_URL:-}" ]; then
+  curl -m 1 -sS -X POST "$TT_BRIDGE_URL/toast" \
+    -H "Content-Type: application/json" \
+    -d '{"text":"tmux env OK"}' >/dev/null 2>&1 || true
+fi
+
+echo "==== $(date) starting runner (tmux) ===="
+export PYTHONUNBUFFERED=1
+export PYTHONFAULTHANDLER=1
+
+python3 - <<'PY'
+import runpy, sys, traceback
+print("PY LAUNCH: importing runner.py"); sys.stdout.flush()
+try:
+    runpy.run_path("/root/projects/apps/service-outage-monitor/runner.py", run_name="__main__")
+except SystemExit as e:
+    print(f"PY SystemExit: {e.code}"); sys.stdout.flush(); raise
+except Exception:
+    print("PY EXCEPTION BELOW >>>"); traceback.print_exc(); sys.stdout.flush()
+    raise
+PY
+ec=$?
+
+echo "PY EXIT:$ec @ $(date)"
+echo "[tmux] runner exited; keeping shell open"
+exec bash
+SH
+chmod +x "$CHILD_SCRIPT"
+
+export TT_BRIDGE_URL TT_BRIDGE_TOKEN TT_BRIDGE_ENABLED
+export APP_DIR VENV_ACTIVATE RUNNER LOG_DIR
+: "${PYTHONPATH:=}"; export PYTHONPATH="$APP_DIR:$APP_DIR/src${PYTHONPATH:+:$PYTHONPATH}"
+
+if command -v tmux >/dev/null 2>&1; then
+  tmux start-server || true
+  tmux set-option -g exit-empty off || true
+
+  created=0
+  for try in 1 2 3; do
+    if tmux new -d -s outage-runner "bash -lc '$CHILD_SCRIPT'"; then
+      created=1
+      echo "[startup] tmux session created on try $try"
+      break
+    else
+      echo "[startup] tmux launch retry $try…"
+      sleep 3
+    fi
+  done
+
+  if [ "$created" -eq 1 ]; then
+    deadline=$(( $(date +%s) + 90 ))
+    started=0
+    hb="$LOG_DIR/runner.heartbeat"
+    while [ "$(date +%s)" -lt "$deadline" ]; do
+      if [ -f "$hb" ] && [ $(( $(date +%s) - $(stat -c %Y "$hb" 2>/dev/null || echo 0) )) -lt 30 ]; then
+        started=1
+        break
+      fi
+      sleep 3
+    done
+
+    if [ "$started" -ne 1 ]; then
+      echo "[startup] watchdog: no heartbeat; relaunching tmux once"
+      tmux has-session -t outage-runner 2>/dev/null && tmux kill-session -t outage-runner || true
+      tmux new -d -s outage-runner "bash -lc '$CHILD_SCRIPT'" || true
+    fi
+  else
+    echo "[startup] ERROR: failed to create tmux session after retries"
+  fi
+
+  curl -m 1 -sS -X POST "$TT_BRIDGE_URL/toast" -H "Content-Type: application/json" \
+    -d '{"text":"✅ runner launch attempted (tmux)"}' >/dev/null 2>&1 || true
+else
+  echo "[startup] tmux not found; using setsid+nohup fallback…"
+  curl -m 1 -sS -X POST "$TT_BRIDGE_URL/toast" -H "Content-Type: application/json" \
+    -d '{"text":"▶️ launching outage-runner (nohup)"}' >/dev/null 2>&1 || true
+  pkill -f 'python3 -u .*runner.py' || true
+
+  source "$VENV_ACTIVATE"
+  cd "$APP_DIR" || true
+  echo "==== $(date) starting runner (setsid) ====" >> "$LOG_DIR/runner.out"
+  setsid -f nohup bash -lc '
+    set -Eeuo pipefail
+    exec >> "'"$LOG_DIR"'/runner.out" 2>&1
+    set -x
+    export PYTHONUNBUFFERED=1
+    python3 -u "'"$RUNNER"'"
+    echo "PY EXIT:$? @ $(date)"
+  ' >/dev/null 2>&1
+
+  curl -m 1 -sS -X POST "$TT_BRIDGE_URL/toast" -H "Content-Type: application/json" \
+    -d '{"text":"✅ runner launched (nohup)"}' >/dev/null 2>&1 || true
+fi
+
+curl -m 1 -sS -X POST "$TT_BRIDGE_URL/toast" -H "Content-Type: application/json" \
+  -d "{\"text\":\"✅ proot startup done @ $(date +%H:%M:%S)\"}" >/dev/null 2>&1 || true
+
+echo "[startup] $(date) done"

--- a/scripts/termux_boot_00_start_ubuntu_sshd.sh
+++ b/scripts/termux_boot_00_start_ubuntu_sshd.sh
@@ -1,0 +1,5 @@
+#!/data/data/com.termux/files/usr/bin/bash
+termux-wake-lock
+sleep 10
+proot-distro login ubuntu-jammy -- bash -lc 'bash ~/sshd_commands.sh start'
+termux-notification --title "SSHD" --content "Ubuntu SSHD started at boot"

--- a/scripts/termux_boot_01_notify_bridge.sh
+++ b/scripts/termux_boot_01_notify_bridge.sh
@@ -1,0 +1,7 @@
+#!/data/data/com.termux/files/usr/bin/sh
+# Boot script for notification bridge
+export TT_BRIDGE_TOKEN="super-secret-change-me"
+
+sleep 15
+pkill -f tt_notify_bridge.py 2>/dev/null
+nohup ~/.local/bin/tt_notify_bridge.py >~/logs/notify_bridge.log 2>&1 &

--- a/scripts/termux_boot_start.sh
+++ b/scripts/termux_boot_start.sh
@@ -1,0 +1,65 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# start.sh — Termux boot launcher
+set -Eeuo pipefail
+
+exec 9> "$HOME/.boot.lock"; flock -n 9 || exit 0
+LOG="$HOME/boot.log"
+exec >>"$LOG" 2>&1
+
+echo
+ echo "==== BOOT $(date) ===="
+termux-wake-lock
+
+sleep 5
+
+echo "[Termux] starting sshd…"
+sshd || echo "[Termux] sshd already running?"
+
+echo "[Termux] waiting for 127.0.0.1:8022 …"
+for i in $(seq 1 30); do
+  if nc -z 127.0.0.1 8022 2>/dev/null; then
+    termux-notification --id 18022 --title "Termux SSH" --content "Now Listening (8022)"
+    echo "[Termux] sshd is listening."
+    break
+  fi
+  sleep 1
+done
+
+echo "[Ubuntu] launching startup…"
+
+if command -v termux-wifi-connectioninfo >/dev/null 2>&1; then
+  for i in $(seq 1 20); do
+    LAN_IP="$(termux-wifi-connectioninfo | sed -n 's/.*"ip":"\([^"]*\)".*/\1/p')"
+    termux-notification --id 130022 --title "Server IP" --content "IP Live: ${LAN_IP:-unknown}"
+    [ -n "${LAN_IP:-}" ] && break
+    sleep 1
+  done
+fi
+: "${LAN_IP:=127.0.0.1}"
+
+echo "[boot] LAN_IP=$LAN_IP"
+
+for wait in 0 3 5 8 10; do
+  sleep "$wait"
+  if proot-distro login ubuntu-jammy -- bash -lc '/root/startup.sh'; then
+    echo "[boot] ubuntu startup ok (wait=$wait)"
+    break
+  else
+    echo "[boot] ubuntu startup failed (wait=$wait), retrying…"
+  fi
+done
+
+for i in $(seq 1 30); do
+  if nc -z 127.0.0.1 30022 2>/dev/null; then
+    if nc -z "$LAN_IP" 30022 2>/dev/null; then
+      termux-notification --id 130023 --title "Ubuntu" --content "SSH on $LAN_IP:30022"
+    else
+      termux-notification --id 130023 --title "Ubuntu" --content "SSH on 127.0.0.1:30022"
+    fi
+    echo "[boot] Ubuntu SSH listening"
+    break
+  fi
+  sleep 1
+done
+
+echo "==== BOOT DONE $(date) ===="

--- a/scripts/tt_notify_bridge.py
+++ b/scripts/tt_notify_bridge.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Tiny Termux notification bridge for proot/Ubuntu -> Termux API.
+
+This script exposes a small HTTP server on localhost:8787 and translates
+/pro toast and /notify requests into Termux commands.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shlex
+import signal
+import subprocess
+import sys
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any
+
+DEFAULT_HOST = "127.0.0.1"
+DEFAULT_PORT = 8787
+TOKEN_ENV = "TT_BRIDGE_TOKEN"
+DEFAULT_TOKEN = "super-secret-change-me"
+
+
+class BridgeHandler(BaseHTTPRequestHandler):
+    server_version = "TTBridge/1.0"
+
+    def _reply(self, status: int, body: dict[str, Any]) -> None:
+        payload = json.dumps(body).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def do_GET(self) -> None:  # noqa: N802
+        if self.path == "/health":
+            self._reply(200, {"ok": True, "token": os.environ.get(TOKEN_ENV, DEFAULT_TOKEN)})
+            return
+        self._reply(404, {"ok": False, "error": "not found"})
+
+    def do_POST(self) -> None:  # noqa: N802
+        token = self.headers.get("X-TT-Token") or ""
+        expected = os.environ.get(TOKEN_ENV, DEFAULT_TOKEN)
+        if token != expected:
+            self._reply(401, {"ok": False, "error": "invalid token"})
+            return
+
+        length = int(self.headers.get("Content-Length", "0"))
+        raw = self.rfile.read(length) if length else b"{}"
+        try:
+            payload = json.loads(raw.decode("utf-8", errors="ignore"))
+        except json.JSONDecodeError:
+            self._reply(400, {"ok": False, "error": "invalid json"})
+            return
+
+        path = self.path
+        if path == "/toast":
+            text = str(payload.get("text", "")).strip()
+            ok = run_termux(["termux-toast", text]) if text else False
+            self._reply(200 if ok else 500, {"ok": ok, "path": path, "text": text})
+            return
+
+        if path == "/notify":
+            ok = run_notify(payload)
+            self._reply(200 if ok else 500, {"ok": ok, "path": path, "title": payload.get("title", "")})
+            return
+
+        self._reply(404, {"ok": False, "error": "unknown path"})
+
+    def log_message(self, format: str, *args: Any) -> None:  # noqa: A003
+        sys.stderr.write("[tt_notify_bridge] %s\n" % (format % args))
+
+
+def run_termux(command: list[str]) -> bool:
+    try:
+        subprocess.run(command, check=False, capture_output=True, text=True)
+        return True
+    except Exception:
+        return False
+
+
+def run_notify(payload: dict[str, Any]) -> bool:
+    title = str(payload.get("title", "")).strip() or "Notification"
+    content = str(payload.get("content", "")).strip() or ""
+    priority = str(payload.get("priority", "default")).strip() or "default"
+    sticky = bool(payload.get("sticky", False))
+
+    command = ["termux-notification", "--title", title, "--content", content, "--priority", priority]
+    if sticky:
+        command.append("--sticky")
+
+    # Optional extra buttons (if provided by the caller)
+    for key in ("button1", "button2", "button3"):
+        if payload.get(key):
+            command.extend(["--button", f"{key}:{payload[key]}"])
+    if payload.get("button1_action"):
+        command.extend(["--button-action", payload["button1_action"]])
+
+    return run_termux(command)
+
+
+def serve(host: str, port: int) -> None:
+    httpd = ThreadingHTTPServer((host, port), BridgeHandler)
+    print(f"[tt_notify_bridge] listening on http://{host}:{port}", flush=True)
+    try:
+        httpd.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        httpd.server_close()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Start the Termux notification bridge server")
+    parser.add_argument("--host", default=DEFAULT_HOST)
+    parser.add_argument("--port", type=int, default=DEFAULT_PORT)
+    parser.add_argument("--token", default=os.environ.get(TOKEN_ENV, DEFAULT_TOKEN))
+    args = parser.parse_args()
+
+    os.environ[TOKEN_ENV] = args.token
+    serve(args.host, args.port)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/main.py
+++ b/src/main.py
@@ -1,5 +1,6 @@
 # main.py
 from datetime import datetime
+from pathlib import Path
 from html import escape
 import yaml
 
@@ -12,7 +13,17 @@ from src.mailer.email_format_util import format_events_as_html, format_criteria_
 
 logger = setup_logging("service-outage-monitor")
 
-def load_config(path="config/config.yaml"):
+def load_config(path=None):
+    base_dir = Path(__file__).resolve().parent.parent / "config"
+    if path is None:
+        local_path = base_dir / "config.yaml"
+        example_path = base_dir / "config.example.yaml"
+        if local_path.exists():
+            path = local_path
+        else:
+            path = example_path
+            logger.warning("No local config/config.yaml found; using example config instead.")
+
     with open(path, "r", encoding="utf-8") as f:
         return yaml.safe_load(f)
 


### PR DESCRIPTION
This pull request introduces comprehensive improvements for running the service outage monitor on Android devices using Termux and proot. It adds robust automation scripts for setup, boot-time initialization, and SSH access, along with enhanced documentation and improved error handling and logging in the Python runner. The configuration workflow is clarified, and example config files are separated from user secrets.

**Termux/proot/Android support and automation:**

* Added `scripts/install_termux.sh` to automate setup on Termux, including package installation, config file creation, boot/notification helper setup, proot/Ubuntu bootstrap, and virtualenv preparation.
* Added proot/Ubuntu startup scripts: `proot_startup.sh` for initializing the runner in a tmux session, `proot_start-sshd-once.sh` for one-time SSHD startup, and `proot_sshd_commands.sh` for SSHD management (start/stop/status/test/monitor via menu or CLI). [[1]](diffhunk://#diff-3ee4be3227fa17d4e561196164da9967d520a1387f3f20c65c6fb006b5f207afR1-R200) [[2]](diffhunk://#diff-fc776249c250d10704941d338a90f067f738ddc73f98a04845d23f1370a13bf0R1-R12) [[3]](diffhunk://#diff-52a7a9f44f6c8f5a7a13ef586e61e4b8f1fee63764af99ccb7e31646ee0b010eR1-R105)
* Added Termux boot scripts: `termux_boot_00_start_ubuntu_sshd.sh` (starts SSHD at boot) and `termux_boot_01_notify_bridge.sh` (starts notification bridge at boot). [[1]](diffhunk://#diff-cbc892b0e19e2f6a0a7e3ecd852ea1aa3aa8e0d50d8dc36ff8cdc191f6a10b5eR1-R5) [[2]](diffhunk://#diff-5b575c6af776dc158ec34157d7e4ac0c0abdbad9b3da0fd7fee3f52878116e8dR1-R7)

**Documentation and configuration improvements:**

* Updated `README.md` with detailed Termux-first setup and boot workflow instructions, including usage of the new installer and guidance for configuration and first run. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R51-R73) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R136-R143)
* Renamed `config/config.yaml` to `config/config.example.yaml` and updated example values, clarifying that users should copy and edit their own secrets/configs. [[1]](diffhunk://#diff-8cc50e4efba8e886ce7818959b4fbdd6f67435818001afd0baf2ffaad7b028a6L1-R2) [[2]](diffhunk://#diff-8cc50e4efba8e886ce7818959b4fbdd6f67435818001afd0baf2ffaad7b028a6L10-R26)

**Python runner robustness and logging:**

* Enhanced logging and error handling in `runner.py` for all critical steps: recipient checks, scraping, event creation, ICS file saving, and email sending. Now logs detailed information and exceptions for easier debugging and monitoring. [[1]](diffhunk://#diff-34cde5e49b54d9b67952c80d3580b6c421ebcf16097996e215aef54e44f78562R108-R126) [[2]](diffhunk://#diff-34cde5e49b54d9b67952c80d3580b6c421ebcf16097996e215aef54e44f78562R140-R144) [[3]](diffhunk://#diff-34cde5e49b54d9b67952c80d3580b6c421ebcf16097996e215aef54e44f78562R153-R162) [[4]](diffhunk://#diff-34cde5e49b54d9b67952c80d3580b6c421ebcf16097996e215aef54e44f78562R174-R186) [[5]](diffhunk://#diff-34cde5e49b54d9b67952c80d3580b6c421ebcf16097996e215aef54e44f78562R199-R204) [[6]](diffhunk://#diff-34cde5e49b54d9b67952c80d3580b6c421ebcf16097996e215aef54e44f78562R254-R255)

These changes together make it much easier to deploy, monitor, and debug the outage monitor app on Android devices using Termux and proot, with clear separation between example and secret configuration.…notification bridge