### PR TITLE
feat: implement staged installation scripts for Termux setup

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -25,7 +25,8 @@ This folder holds the helper scripts used by the Termux + proot runtime.
 5. Start the boot hooks with `termux-boot` or reboot the phone.
 
 ## What each script does
-- `install_termux.sh` — installs the required Termux packages, creates the local config, and wires the boot/notification hooks.
+- `install_termux.sh` — thin entrypoint that delegates the runtime setup to the staged helpers under `install/`.
+- `install/*.sh` — stage-based setup flow for package install, boot hooks, proot bootstrap, Python env, and local config.
 - `tt_notify_bridge.py` — lightweight HTTP bridge used by the proot runner to show toasts and notifications via Termux API.
 - `proot_startup.sh` — proot-side launcher that starts the runner in tmux or nohup.
 - `proot_sshd_commands.sh` and `proot_start-sshd-once.sh` — SSH service helpers for the Ubuntu proot session.

--- a/scripts/install/01_base_packages.sh
+++ b/scripts/install/01_base_packages.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+stage_base_packages() {
+  say "Stage 1/5: base Termux packages"
+
+  if prompt_yes_no "Install/update required Termux packages (pkg update + git/python/proot-distro/termux-api/termux-tools/tmux/openssh/curl/libxml2/libxslt/pkg-config/clang/make)?"; then
+    say "Running pkg update..."
+    pkg update -y
+    pkg install -y \
+      git python proot-distro termux-api termux-tools tmux openssh curl \
+      libxml2 libxslt pkg-config clang make
+  fi
+
+  ensure_cmd git git
+  ensure_cmd sshd openssh
+
+  if prompt_yes_no "Install optional termux-boot support too?"; then
+    if pkg list termux-boot >/dev/null 2>&1; then
+      pkg install -y termux-boot || true
+    else
+      say "termux-boot package is not available in this environment; skipping that optional step."
+    fi
+  fi
+}

--- a/scripts/install/02_boot_helpers.sh
+++ b/scripts/install/02_boot_helpers.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+stage_boot_helpers() {
+  say "Stage 2/5: install Termux boot + notification helpers"
+
+  ensure_dir "$BOOT_DIR"
+  ensure_dir "$LOCAL_BIN"
+  ensure_dir "$LOG_DIR"
+
+  say "Installing bridge helper to $LOCAL_BIN/tt_notify_bridge.py"
+  copy_file "$REPO_ROOT/scripts/tt_notify_bridge.py" "$LOCAL_BIN/tt_notify_bridge.py"
+  BOOT_HELPER_CREATED=1
+
+  say "Installing Termux boot files to $BOOT_DIR"
+  copy_file "$REPO_ROOT/scripts/termux_boot_start.sh" "$BOOT_DIR/start.sh"
+  copy_file "$REPO_ROOT/scripts/termux_boot_00_start_ubuntu_sshd.sh" "$BOOT_DIR/00_start_ubuntu_sshd.sh"
+  copy_file "$REPO_ROOT/scripts/termux_boot_01_notify_bridge.sh" "$BOOT_DIR/01_notify_bridge.sh"
+}

--- a/scripts/install/03_proot_helpers.sh
+++ b/scripts/install/03_proot_helpers.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+stage_proot_helpers() {
+  say "Stage 3/5: install proot helper shells"
+
+  copy_file "$REPO_ROOT/scripts/proot_startup.sh" "$TERMUX_HOME/startup.sh"
+  copy_file "$REPO_ROOT/scripts/proot_sshd_commands.sh" "$TERMUX_HOME/sshd_commands.sh"
+  copy_file "$REPO_ROOT/scripts/proot_start-sshd-once.sh" "$TERMUX_HOME/start-sshd-once.sh"
+  PROOT_HELPER_CREATED=1
+}

--- a/scripts/install/04_proot_distro.sh
+++ b/scripts/install/04_proot_distro.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+stage_proot_distro() {
+  say "Stage 4/5: prepare the proot distro"
+
+  if ! command -v proot-distro >/dev/null 2>&1; then
+    echo "[install] proot-distro not found after package install; please reopen Termux and rerun." >&2
+    exit 1
+  fi
+
+  distro_name="${TT_PROOT_DISTRO:-ubuntu}"
+  if proot-distro list 2>/dev/null | grep -q "$distro_name"; then
+    say "proot distro '$distro_name' is already installed."
+    return 0
+  fi
+
+  say "Installing proot distro '$distro_name'..."
+  say "This can take several minutes. Keep Termux open and do not close it while the image downloads."
+
+  if ! proot-distro install "$distro_name" 2>/dev/null; then
+    say "Primary distro install failed. Falling back to ubuntu-focal..."
+    proot-distro install ubuntu-focal 2>/dev/null || true
+    say "Falling back to ubuntu-jammy..."
+    proot-distro install ubuntu-jammy 2>/dev/null || true
+  fi
+}

--- a/scripts/install/05_python_env.sh
+++ b/scripts/install/05_python_env.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+stage_python_env() {
+  say "Stage 5/5: create the local virtualenv and install Python dependencies"
+
+  ensure_dir "$PROJECT_DIR"
+
+  if [[ ! -d "$REPO_ROOT/.venv" ]]; then
+    VENV_CREATED=1
+    say "Creating the project virtualenv in $REPO_ROOT/.venv. This can take a few minutes."
+    if command -v python >/dev/null 2>&1; then
+      python -m venv "$REPO_ROOT/.venv"
+    else
+      python3 -m venv "$REPO_ROOT/.venv"
+    fi
+  else
+    say "Reusing existing .venv at $REPO_ROOT/.venv"
+  fi
+
+  "$REPO_ROOT/.venv/bin/python" -m pip install --upgrade pip
+  "$REPO_ROOT/.venv/bin/pip" install -r "$REPO_ROOT/requirements.txt"
+}

--- a/scripts/install/06_local_config.sh
+++ b/scripts/install/06_local_config.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+stage_local_config() {
+  say "Stage 6/6: prepare local config files"
+
+  if [[ ! -f "$REPO_ROOT/config/config.yaml" ]]; then
+    CONFIG_CREATED=1
+    cp "$REPO_ROOT/config/config.example.yaml" "$REPO_ROOT/config/config.yaml"
+    echo "[install] Created $REPO_ROOT/config/config.yaml from the example template. Edit your real keywords here."
+  fi
+
+  if [[ ! -f "$REPO_ROOT/.env" ]]; then
+    ENV_CREATED=1
+    cp "$REPO_ROOT/.env.example" "$REPO_ROOT/.env"
+    echo "[install] Created $REPO_ROOT/.env. Edit SMTP and recipient settings before first run."
+  fi
+}

--- a/scripts/install/common.sh
+++ b/scripts/install/common.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+say() {
+  printf '\n[install] %s\n' "$1"
+}
+
+prompt_yes_no() {
+  local prompt="$1"
+  local default="${2:-n}"
+  local answer=""
+
+  while true; do
+    if [[ "$default" == "y" ]]; then
+      read -r -p "$prompt [Y/n]: " answer
+      answer="${answer:-y}"
+    else
+      read -r -p "$prompt [y/N]: " answer
+      answer="${answer:-n}"
+    fi
+
+    case "${answer,,}" in
+      y|yes) return 0 ;;
+      n|no) return 1 ;;
+      *) echo "Please answer yes or no." ;;
+    esac
+  done
+}
+
+require_termux() {
+  if ! command -v pkg >/dev/null 2>&1; then
+    echo "[install] This installer must run inside Termux." >&2
+    exit 1
+  fi
+}
+
+ensure_cmd() {
+  local name="$1"
+  shift
+
+  if command -v "$name" >/dev/null 2>&1; then
+    return 0
+  fi
+
+  say "${name} is missing; installing it now..."
+  pkg install -y "$@" || pkg install -y "$name"
+}
+
+ensure_dir() {
+  mkdir -p "$1"
+}
+
+copy_file() {
+  local src="$1"
+  local dst="$2"
+
+  ensure_dir "$(dirname "$dst")"
+  cp "$src" "$dst"
+  chmod +x "$dst" 2>/dev/null || true
+}

--- a/scripts/install_termux.sh
+++ b/scripts/install_termux.sh
@@ -16,6 +16,9 @@ ENV_CREATED=0
 BOOT_HELPER_CREATED=0
 PROOT_HELPER_CREATED=0
 
+export TERMUX_HOME BOOT_DIR LOCAL_BIN LOG_DIR PROJECT_DIR REPO_ROOT BACKUP_DIR
+export VENV_CREATED CONFIG_CREATED ENV_CREATED BOOT_HELPER_CREATED PROOT_HELPER_CREATED
+
 cleanup_on_error() {
   local exit_code=${1:-$?}
   if [[ $exit_code -eq 0 ]]; then
@@ -23,52 +26,35 @@ cleanup_on_error() {
   fi
 
   echo "[install] Setup failed (exit $exit_code); cleaning up partial changes..." >&2
-  if [[ $VENV_CREATED -eq 1 && -d "$REPO_ROOT/.venv" ]]; then
+  if [[ ${VENV_CREATED:-0} -eq 1 && -d "$REPO_ROOT/.venv" ]]; then
     rm -rf "$REPO_ROOT/.venv"
   fi
-  if [[ $CONFIG_CREATED -eq 1 && -f "$REPO_ROOT/config/config.yaml" ]]; then
+  if [[ ${CONFIG_CREATED:-0} -eq 1 && -f "$REPO_ROOT/config/config.yaml" ]]; then
     rm -f "$REPO_ROOT/config/config.yaml"
   fi
-  if [[ $ENV_CREATED -eq 1 && -f "$REPO_ROOT/.env" ]]; then
+  if [[ ${ENV_CREATED:-0} -eq 1 && -f "$REPO_ROOT/.env" ]]; then
     rm -f "$REPO_ROOT/.env"
   fi
-  if [[ $BOOT_HELPER_CREATED -eq 1 ]]; then
+  if [[ ${BOOT_HELPER_CREATED:-0} -eq 1 ]]; then
     rm -f "$LOCAL_BIN/tt_notify_bridge.py" || true
     rm -f "$BOOT_DIR/start.sh" "$BOOT_DIR/00_start_ubuntu_sshd.sh" "$BOOT_DIR/01_notify_bridge.sh" || true
   fi
-  if [[ $PROOT_HELPER_CREATED -eq 1 ]]; then
+  if [[ ${PROOT_HELPER_CREATED:-0} -eq 1 ]]; then
     rm -f "$TERMUX_HOME/startup.sh" "$TERMUX_HOME/sshd_commands.sh" "$TERMUX_HOME/start-sshd-once.sh" || true
   fi
   rm -rf "$BACKUP_DIR"
 }
 trap 'cleanup_on_error $?' ERR
 
-if ! command -v pkg >/dev/null 2>&1; then
-  echo "[install] This installer must run inside Termux." >&2
-  exit 1
-fi
+source "$SCRIPT_DIR/install/common.sh"
+source "$SCRIPT_DIR/install/01_base_packages.sh"
+source "$SCRIPT_DIR/install/02_boot_helpers.sh"
+source "$SCRIPT_DIR/install/03_proot_helpers.sh"
+source "$SCRIPT_DIR/install/04_proot_distro.sh"
+source "$SCRIPT_DIR/install/05_python_env.sh"
+source "$SCRIPT_DIR/install/06_local_config.sh"
 
-prompt_yes_no() {
-  local prompt="$1"
-  local default="${2:-n}"
-  local answer=""
-  while true; do
-    if [[ "$default" == "y" ]]; then
-      read -r -p "$prompt [Y/n]: " answer
-      answer="${answer:-y}"
-    else
-      read -r -p "$prompt [y/N]: " answer
-      answer="${answer:-n}"
-    fi
-    case "${answer,,}" in
-      y|yes) return 0 ;;
-      n|no) return 1 ;;
-      *) echo "Please answer yes or no." ;;
-    esac
-  done
-}
-
-say() { printf '\n[install] %s\n' "$1"; }
+require_termux
 
 say "Detected Termux user: $(whoami)"
 say "Repo root: $REPO_ROOT"
@@ -78,69 +64,10 @@ if [[ ! -f "$REPO_ROOT/requirements.txt" ]]; then
   exit 1
 fi
 
-if prompt_yes_no "Install/update required Termux packages (pkg update + git/python/proot-distro/termux-api/termux-tools/tmux/openssh/curl/libxml2/libxslt)?"; then
-  say "Running pkg update..."
-  pkg update -y
-  pkg install -y git python proot-distro termux-api termux-tools tmux openssh curl libxml2 libxslt libxml2-dev libxslt-dev pkg-config clang make
-fi
-
-if ! command -v git >/dev/null 2>&1; then
-  say "git is not available; installing it now..."
-  pkg install -y git
-fi
-
-if ! command -v sshd >/dev/null 2>&1; then
-  say "openssh is not available; installing it now..."
-  pkg install -y openssh
-fi
-
-if prompt_yes_no "Install Termux boot support package too?"; then
-  if pkg list termux-boot >/dev/null 2>&1; then
-    pkg install -y termux-boot || true
-  else
-    say "termux-boot package is not available in this repo; skipping that optional step."
-  fi
-fi
-
-mkdir -p "$BOOT_DIR" "$LOCAL_BIN" "$LOG_DIR"
-
-say "Installing bridge helper to $LOCAL_BIN/tt_notify_bridge.py"
-mkdir -p "$LOCAL_BIN"
-cp "$REPO_ROOT/scripts/tt_notify_bridge.py" "$LOCAL_BIN/tt_notify_bridge.py"
-chmod +x "$LOCAL_BIN/tt_notify_bridge.py"
-BOOT_HELPER_CREATED=1
-
-say "Installing Termux boot files to $BOOT_DIR"
-mkdir -p "$BOOT_DIR"
-cp "$REPO_ROOT/scripts/termux_boot_start.sh" "$BOOT_DIR/start.sh"
-cp "$REPO_ROOT/scripts/termux_boot_00_start_ubuntu_sshd.sh" "$BOOT_DIR/00_start_ubuntu_sshd.sh"
-cp "$REPO_ROOT/scripts/termux_boot_01_notify_bridge.sh" "$BOOT_DIR/01_notify_bridge.sh"
-chmod +x "$BOOT_DIR"/*.sh
-
-say "Installing proot helper shells into $TERMUX_HOME"
-cp "$REPO_ROOT/scripts/proot_startup.sh" "$TERMUX_HOME/startup.sh"
-cp "$REPO_ROOT/scripts/proot_sshd_commands.sh" "$TERMUX_HOME/sshd_commands.sh"
-cp "$REPO_ROOT/scripts/proot_start-sshd-once.sh" "$TERMUX_HOME/start-sshd-once.sh"
-chmod +x "$TERMUX_HOME/startup.sh" "$TERMUX_HOME/sshd_commands.sh" "$TERMUX_HOME/start-sshd-once.sh"
-PROOT_HELPER_CREATED=1
-
-say "Checking proot distro availability"
-if command -v proot-distro >/dev/null 2>&1; then
-  distro_name="${TT_PROOT_DISTRO:-ubuntu}"
-  if proot-distro list 2>/dev/null | grep -q "$distro_name"; then
-    say "proot distro '$distro_name' is already installed."
-  else
-    say "Installing proot distro '$distro_name'..."
-    say "This can take several minutes. Keep Termux open and do not close it while the image downloads."
-    if ! proot-distro install "$distro_name" 2>/dev/null; then
-      say "Primary distro install failed. Trying ubuntu-focal..."
-      proot-distro install ubuntu-focal 2>/dev/null || proot-distro install ubuntu-jammy 2>/dev/null || true
-    fi
-  fi
-else
-  echo "[install] proot-distro not found after package install; please reopen Termux and rerun." >&2
-  exit 1
-fi
+stage_base_packages
+stage_boot_helpers
+stage_proot_helpers
+stage_proot_distro
 
 say "Creating project directory if needed: $PROJECT_DIR"
 mkdir -p "$PROJECT_DIR"
@@ -151,35 +78,8 @@ else
   say "This installer expects the repo to already be cloned into $REPO_ROOT"
 fi
 
-if [[ ! -f "$REPO_ROOT/requirements.txt" ]]; then
-  echo "[install] Missing requirements.txt in repo. Clone the project first." >&2
-  exit 1
-fi
-
-say "Creating a local virtualenv for the project"
-if [[ ! -d "$REPO_ROOT/.venv" ]]; then
-  VENV_CREATED=1
-  say "This can take a few minutes because Python packages are being installed. Keep Termux open."
-  python -m venv "$REPO_ROOT/.venv" || python3 -m venv "$REPO_ROOT/.venv"
-else
-  say "Reusing existing .venv at $REPO_ROOT/.venv"
-fi
-"$REPO_ROOT/.venv/bin/python" -m pip install --upgrade pip
-"$REPO_ROOT/.venv/bin/pip" install -r "$REPO_ROOT/requirements.txt"
-
-say "Preparing local config from the example template if needed"
-if [[ ! -f "$REPO_ROOT/config/config.yaml" ]]; then
-  CONFIG_CREATED=1
-  cp "$REPO_ROOT/config/config.example.yaml" "$REPO_ROOT/config/config.yaml"
-  echo "[install] Created $REPO_ROOT/config/config.yaml from the example template. Edit your real keywords here."
-fi
-
-say "Preparing .env from .env.example if it does not exist"
-if [[ ! -f "$REPO_ROOT/.env" ]]; then
-  ENV_CREATED=1
-  cp "$REPO_ROOT/.env.example" "$REPO_ROOT/.env"
-  echo "[install] Created $REPO_ROOT/.env. Edit SMTP and recipient settings before first run."
-fi
+stage_python_env
+stage_local_config
 
 say "Starting Termux SSHD for the first run"
 if command -v sshd >/dev/null 2>&1; then


### PR DESCRIPTION
This pull request refactors the Termux + proot runtime installation scripts to use a modular, stage-based approach. The main installer (`install_termux.sh`) now delegates each part of the setup to dedicated helper scripts under the new `install/` directory, improving maintainability and clarity. Common utility functions have been extracted into a shared script, and the documentation has been updated to reflect these changes.

**Installer refactor and modularization:**

* The main script (`install_termux.sh`) now sources and sequentially calls dedicated stage scripts (`01_base_packages.sh`, `02_boot_helpers.sh`, `03_proot_helpers.sh`, `04_proot_distro.sh`, `05_python_env.sh`, `06_local_config.sh`) for each setup step, replacing the previous monolithic implementation. [[1]](diffhunk://#diff-70f53a0aee16cca19bb15725b34c505e8c8a537fbeeb8b60a47bff543be17e44R19-R57) [[2]](diffhunk://#diff-70f53a0aee16cca19bb15725b34c505e8c8a537fbeeb8b60a47bff543be17e44L81-R70) [[3]](diffhunk://#diff-70f53a0aee16cca19bb15725b34c505e8c8a537fbeeb8b60a47bff543be17e44L154-R82)
* Common helper functions (e.g., `say`, `prompt_yes_no`, `require_termux`, `ensure_cmd`, `ensure_dir`, `copy_file`) are moved to a new `common.sh` for reuse across all installer scripts.

**Stage-based setup scripts:**

* New scripts under `install/` implement each setup stage:
  - [`01_base_packages.sh`](diffhunk://#diff-c938e15cdd9fbf130dffe0561e355e469911aa9c67980d4971eb58f7bf0603f1R1-R24): Installs required and optional Termux packages.
  - [`02_boot_helpers.sh`](diffhunk://#diff-7729a1405abd49b95382d8ef4690d4b8bdd5c2096b52e40a09dcba8ad8b290a5R1-R18): Installs Termux boot and notification helpers.
  - [`03_proot_helpers.sh`](diffhunk://#diff-4d69904a7955c3ca5c3f8c384d358cb975d0593fbf60f05d718cd168b7b3e9d0R1-R10): Installs proot helper shells.
  - [`04_proot_distro.sh`](diffhunk://#diff-75deed0c240dde5d0e09a3d1458c9a7205c1d53c35d9c318a776d4094e9d4127R1-R26): Installs and verifies the proot-distro environment, with fallback logic.
  - [`05_python_env.sh`](diffhunk://#diff-b1d9f4c30cf0995a30aa5f63f290d12949aa2adfa778a6a79d308a68402a9dbeR1-R22): Sets up the Python virtual environment and installs dependencies.
  - [`06_local_config.sh`](diffhunk://#diff-d41aad45f34ed191159da6570fe8a4e33ab6829a514ec47f3ffbef7ed40c3a86R1-R17): Prepares local configuration files from templates.

**Documentation update:**

* The `README.md` is updated to describe the new modular install flow, clarifying the responsibilities of each script.